### PR TITLE
fixed dropdown hashtag selector modal

### DIFF
--- a/src/components/ui/modals/HashtagSelector.tsx
+++ b/src/components/ui/modals/HashtagSelector.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Hash } from "lucide-react"
-
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 
@@ -39,11 +38,6 @@ export function HashtagSelector({ open, onOpenChange, selectedTags, onTagsChange
 
         <DialogHeader className="">
           <DialogTitle className="text-xl font-semibold flex items-center justify-center text-[#1E2875]">Add Hashtag(s)</DialogTitle>
-
-          {/* <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onOpenChange(false)}>
-            <X className="h-4 w-4" />
-          </Button> */}
-
         </DialogHeader>
         <DialogDescription className="text-center text-[#1E2875] pb-4">
           Hashtags helps other users find your wager easily and quickly.

--- a/src/components/ui/modals/HashtagSelector.tsx
+++ b/src/components/ui/modals/HashtagSelector.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Hash } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+const HASHTAGS = [
+  "Bitcoin",
+  "STRKBet",
+  "BTCto100k",
+  "CryptoBetting",
+  "BlockchainWager",
+  "CryptoTrends",
+  "Web3Challenge",
+  "ETH",
+  "DeFiPrediction",
+]
+
+interface HashtagSelectorProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedTags: string[]
+  onTagsChange: (tags: string[]) => void
+}
+
+export function HashtagSelector({ open, onOpenChange, selectedTags, onTagsChange }: HashtagSelectorProps) {
+  const toggleTag = (tag: string) => {
+    if (selectedTags.includes(tag)) {
+      onTagsChange(selectedTags.filter((t) => t !== tag))
+    } else if (selectedTags.length < 4) {
+      onTagsChange([...selectedTags, tag])
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-sm sm:max-w-md md:max-w-lg lg:max-w-xl mx-auto px-2 sm:px-4">
+
+        <DialogHeader className="">
+          <DialogTitle className="text-xl font-semibold flex items-center justify-center text-[#1E2875]">Add Hashtag(s)</DialogTitle>
+
+          {/* <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onOpenChange(false)}>
+            <X className="h-4 w-4" />
+          </Button> */}
+
+        </DialogHeader>
+        <DialogDescription className="text-center text-[#1E2875] pb-4">
+          Hashtags helps other users find your wager easily and quickly.
+        </DialogDescription>
+        <div className="grid grid-cols-2 gap-2">
+          {HASHTAGS.map((tag) => (
+            <Button
+              key={tag}
+              variant={selectedTags.includes(tag) ? "default" : "outline"}
+              onClick={() => toggleTag(tag)}
+              className={`flex items-center justify-start gap-2 ${
+                selectedTags.includes(tag) ? "bg-[#1E2875] text-white hover:bg-[#1E2875]/90" : "hover:bg-[#1E2875]/10"
+              }`}
+              disabled={!selectedTags.includes(tag) && selectedTags.length >= 4}
+            >
+              <Hash className="h-4 w-4" />
+              {tag}
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/src/module/dashboard/wagers/create-wager.tsx
+++ b/src/module/dashboard/wagers/create-wager.tsx
@@ -1,16 +1,27 @@
+"use client"
+
 import * as React from "react";
 import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
+} 
+
+from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { getSvgById } from "@/svgs";
+import { HashtagSelector } from "@/components/ui/modals/HashtagSelector";
+
 
 export default function CreateWager() {
+  const [open, setOpen] = useState(false)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+
   return (
     <div className="w-full max-w-xl py-[4rem]  mx-auto">
       <form className="flex flex-col gap-5">
@@ -32,20 +43,19 @@ export default function CreateWager() {
           </div>
 
           <Select>
-            <SelectTrigger className="">
-              <SelectValue placeholder="Add Hashtags" className="flex-grow " />
-            </SelectTrigger>
-            <SelectContent className="border-none text-blue-950">
-              <SelectItem value="tag1">Tag 1</SelectItem>
-              <SelectItem value="tag2">Tag 2</SelectItem>
-              <SelectItem value="tag3">Tag 3</SelectItem>
-            </SelectContent>
+          <SelectTrigger className="" onClick={() => setOpen(true)}>
+          <SelectValue placeholder="Add Hashtags" className="flex-grow" />
+        </SelectTrigger>
           </Select>
-          <div className="flex-shrink-0 absolute right-1 ml-2">
-            {getSvgById("arrowDown", {
-              className: "w-4 h-4",
-            })}
-          </div>
+
+          <HashtagSelector
+        open={open}
+        onOpenChange={setOpen}
+        selectedTags={selectedTags}
+        onTagsChange={setSelectedTags}
+      />
+
+         
         </div>
 
         {/* Title of wager field */}

--- a/src/module/dashboard/wagers/create-wager.tsx
+++ b/src/module/dashboard/wagers/create-wager.tsx
@@ -3,20 +3,11 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} 
-
+import {Select,SelectContent,SelectItem,SelectTrigger,SelectValue,} 
 from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { getSvgById } from "@/svgs";
 import { HashtagSelector } from "@/components/ui/modals/HashtagSelector";
-
 
 export default function CreateWager() {
   const [open, setOpen] = useState(false)
@@ -53,9 +44,7 @@ export default function CreateWager() {
         onOpenChange={setOpen}
         selectedTags={selectedTags}
         onTagsChange={setSelectedTags}
-      />
-
-         
+      /> 
         </div>
 
         {/* Title of wager field */}


### PR DESCRIPTION
## Description


## Type of Change

-HashtagSelector component, a modal-based UI element that allows users to select up to four hashtags for their wagers.

# Key Features:
Dialog-Based UI: Uses Dialog from the UI components to display the modal when triggered.
Hashtag Selection Logic:
Users can toggle hashtags on/off.
A maximum of four hashtags can be selected at a time.
Selected hashtags are visually distinct with a bg-[#1E2875] background.


# Optimized User Experience:
Prevents selecting more than four hashtags.
Uses the lucide-react Hash icon for a clear hashtag representation.
Displays an informative message guiding users on how hashtags improve discoverability.


## Implementation Details:
# Props:
open: Controls modal visibility.
onOpenChange: Handles modal state changes.
selectedTags: Stores selected hashtags.
onTagsChange: Updates the selected hashtags.

# Styling:
grid-cols-2 layout for organized hashtag display.
Button variants for active/inactive hashtags.
Responsive width adjustments for better usability on different screen sizes.


This fix improves the hashtag selection experience, ensuring users can easily categorize their wagers while maintaining a clean and user-friendly interface

## Issue #61

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/86829717-23fc-471c-82f7-f3c6f1d0bd14)

![image](https://github.com/user-attachments/assets/cbb36b64-3736-458b-9b4b-ea5597cc14cd)
