### PR TITLE
Feature/implement wagers page 63

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-dialog": "^1.1.5",
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-tabs": "^1.1.3",
     "@starknet-react/chains": "^3.1.2",
     "@starknet-react/core": "^3.6.4",
     "@tanstack/react-query": "^5.63.0",
@@ -41,5 +42,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@starknet-react/chains':
         specifier: ^3.1.2
         version: 3.1.2
@@ -383,6 +386,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -519,6 +535,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.1.5':
     resolution: {integrity: sha512-eVV7N8jBXAXnyrc+PsOF89O9AfVgGnbLxUtBb0clJ8y8ENMWLARGMI/1/SBRLz7u4HqxLgN71BJ17eono3wcjA==}
     peerDependencies:
@@ -539,6 +581,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.3':
+    resolution: {integrity: sha512-9mFyI30cuRDImbmFF6O2KUJdgEOsGh9Vmx9x/Dh9tOhL7BngmQPQfwW4aejKm5OHpfWIdmeV6ySyuxoOGjtNng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.0':
@@ -3039,6 +3103,18 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3163,6 +3239,32 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-select@2.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/number': 1.1.0
@@ -3198,6 +3300,29 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
+
+  '@radix-ui/react-slot@1.1.2(@types/react@18.3.18)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@radix-ui/react-tabs@1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
@@ -4277,7 +4402,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4299,7 +4424,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/(dashboard)/dashboard/wagers/page.tsx
+++ b/src/app/(dashboard)/dashboard/wagers/page.tsx
@@ -3,7 +3,7 @@ import WagerCards from "@/components/ui/WagerCards";
 
 export default function Wagers() {
   return (
-    <div className="w-full pt-20 flex justify-center items-center">
+    <div className="w-full pt-10 pb-20 md:py-20 flex justify-center items-center ">
       <Tabs defaultValue="account" className="w-[650px]">
         <TabsList className="flex justify-center">
           <TabsTrigger value="active">Active</TabsTrigger>
@@ -25,7 +25,7 @@ export default function Wagers() {
             }}
           />
           <WagerCards
-            wagerStatus="pending"
+            wagerStatus="active"
             question="Will Bitcoin Hit $100k Before January 31, 2025?"
             stakeAmount={100}
             leftUser={{

--- a/src/app/(dashboard)/dashboard/wagers/page.tsx
+++ b/src/app/(dashboard)/dashboard/wagers/page.tsx
@@ -1,7 +1,59 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import WagerCards from "@/components/ui/WagerCards";
+
 export default function Wagers() {
-    return (
-        <div className="w-full">
-            <h1>Wagers Page</h1>
-        </div>
-    )
+  return (
+    <div className="w-full pt-20 flex justify-center items-center">
+      <Tabs defaultValue="account" className="w-[650px]">
+        <TabsList className="flex justify-center">
+          <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="complete">Complete</TabsTrigger>
+        </TabsList>
+        <TabsContent value="active">
+          <WagerCards
+            question="Will Bitcoin Hit $100k Before January 31, 2025?"
+            progress={true}
+            stakeAmount={100}
+            leftUser={{
+              username: "@noyi24_7",
+              icon: "/images/leftWagercardUserOneIcon.svg",
+            }}
+            rightUser={{
+              username: "@babykeem",
+              icon: "/images/rightWagercardUserOneIcon.svg",
+            }}
+          />
+          <WagerCards
+            question="Will Bitcoin Hit $100k Before January 31, 2025?"
+            progress={true}
+            stakeAmount={100}
+            leftUser={{
+              username: "@noyi24_7",
+              icon: "/images/leftWagercardUserOneIcon.svg",
+            }}
+            rightUser={{
+              username: "@babykeem",
+              icon: "/images/rightWagercardUserOneIcon.svg",
+            }}
+          />
+        </TabsContent>
+        <TabsContent value="pending">
+          <WagerCards
+            question="Will Bitcoin Hit $100k Before January 31, 2025?"
+            progress={false}
+            stakeAmount={100}
+            leftUser={{
+              username: "@noyi24_7",
+              icon: "/images/leftWagercardUserOneIcon.svg",
+            }}
+            rightUser={{
+              username: "Awaiting Opponent",
+              icon: "/images/opponent.svg",
+            }}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/wagers/page.tsx
+++ b/src/app/(dashboard)/dashboard/wagers/page.tsx
@@ -12,8 +12,8 @@ export default function Wagers() {
         </TabsList>
         <TabsContent value="active">
           <WagerCards
+            wagerStatus="active"
             question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            progress={true}
             stakeAmount={100}
             leftUser={{
               username: "@noyi24_7",
@@ -25,8 +25,8 @@ export default function Wagers() {
             }}
           />
           <WagerCards
+            wagerStatus="pending"
             question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            progress={true}
             stakeAmount={100}
             leftUser={{
               username: "@noyi24_7",
@@ -40,8 +40,8 @@ export default function Wagers() {
         </TabsContent>
         <TabsContent value="pending">
           <WagerCards
+            wagerStatus="pending"
             question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            progress={false}
             stakeAmount={100}
             leftUser={{
               username: "@noyi24_7",
@@ -50,6 +50,21 @@ export default function Wagers() {
             rightUser={{
               username: "Awaiting Opponent",
               icon: "/images/opponent.svg",
+            }}
+          />
+        </TabsContent>
+        <TabsContent value="complete">
+          <WagerCards
+            wagerStatus="completed"
+            question="Will Bitcoin Hit $100k Before January 31, 2025?"
+            stakeAmount={100}
+            leftUser={{
+              username: "@noyi24_7",
+              icon: "/images/leftWagercardUserOneIcon.svg",
+            }}
+            rightUser={{
+              username: "@babykeem",
+              icon: "/images/rightWagercardUserOneIcon.svg",
             }}
           />
         </TabsContent>

--- a/src/app/(dashboard)/dashboard/wagers/page.tsx
+++ b/src/app/(dashboard)/dashboard/wagers/page.tsx
@@ -1,72 +1,107 @@
+"use client";
+import { useState, useEffect } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import WagerCards from "@/components/ui/WagerCards";
+import WagerCardSkeleton from "@/components/ui/skeletons/wagerCardSkeleton";
 
 export default function Wagers() {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setLoading(false);
+    }, 2000);
+  }, []);
+
   return (
-    <div className="w-full pt-10 pb-20 md:py-20 flex justify-center items-center ">
-      <Tabs defaultValue="account" className="w-[650px]">
+    <div className="w-full pt-10 pb-20 md:py-20 flex justify-center items-center">
+      <Tabs defaultValue="active" className="w-[650px]">
         <TabsList className="flex justify-center">
           <TabsTrigger value="active">Active</TabsTrigger>
           <TabsTrigger value="pending">Pending</TabsTrigger>
           <TabsTrigger value="complete">Complete</TabsTrigger>
         </TabsList>
+
         <TabsContent value="active">
-          <WagerCards
-            wagerStatus="active"
-            question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            stakeAmount={100}
-            leftUser={{
-              username: "@noyi24_7",
-              icon: "/images/leftWagercardUserOneIcon.svg",
-            }}
-            rightUser={{
-              username: "@babykeem",
-              icon: "/images/rightWagercardUserOneIcon.svg",
-            }}
-          />
-          <WagerCards
-            wagerStatus="active"
-            question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            stakeAmount={100}
-            leftUser={{
-              username: "@noyi24_7",
-              icon: "/images/leftWagercardUserOneIcon.svg",
-            }}
-            rightUser={{
-              username: "@babykeem",
-              icon: "/images/rightWagercardUserOneIcon.svg",
-            }}
-          />
+          {loading ? (
+            <div className="space-y-3">
+              <WagerCardSkeleton />
+              <WagerCardSkeleton />
+            </div>
+          ) : (
+            <>
+              <WagerCards
+                wagerId=""
+                wagerStatus="active"
+                question="Will Bitcoin Hit $100k Before January 31, 2025?"
+                stakeAmount={100}
+                leftUser={{
+                  username: "@noyi24_7",
+                  icon: "/images/leftWagercardUserOneIcon.svg",
+                }}
+                rightUser={{
+                  username: "@babykeem",
+                  icon: "/images/rightWagercardUserOneIcon.svg",
+                }}
+              />
+              <WagerCards
+                wagerId=""
+                wagerStatus="active"
+                question="Will Bitcoin Hit $100k Before January 31, 2025?"
+                stakeAmount={100}
+                leftUser={{
+                  username: "@noyi24_7",
+                  icon: "/images/leftWagercardUserOneIcon.svg",
+                }}
+                rightUser={{
+                  username: "@babykeem",
+                  icon: "/images/rightWagercardUserOneIcon.svg",
+                }}
+              />
+            </>
+          )}
         </TabsContent>
+
         <TabsContent value="pending">
-          <WagerCards
-            wagerStatus="pending"
-            question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            stakeAmount={100}
-            leftUser={{
-              username: "@noyi24_7",
-              icon: "/images/leftWagercardUserOneIcon.svg",
-            }}
-            rightUser={{
-              username: "Awaiting Opponent",
-              icon: "/images/opponent.svg",
-            }}
-          />
+          {loading ? (
+            <WagerCardSkeleton />
+          ) : (
+            <WagerCards
+              wagerId=""
+              wagerStatus="pending"
+              question="Will Bitcoin Hit $100k Before January 31, 2025?"
+              stakeAmount={100}
+              leftUser={{
+                username: "@noyi24_7",
+                icon: "/images/leftWagercardUserOneIcon.svg",
+              }}
+              rightUser={{
+                username: "Awaiting Opponent",
+                icon: "/images/opponent.svg",
+              }}
+            />
+          )}
         </TabsContent>
+
         <TabsContent value="complete">
-          <WagerCards
-            wagerStatus="completed"
-            question="Will Bitcoin Hit $100k Before January 31, 2025?"
-            stakeAmount={100}
-            leftUser={{
-              username: "@noyi24_7",
-              icon: "/images/leftWagercardUserOneIcon.svg",
-            }}
-            rightUser={{
-              username: "@babykeem",
-              icon: "/images/rightWagercardUserOneIcon.svg",
-            }}
-          />
+          {loading ? (
+            <WagerCardSkeleton />
+          ) : (
+            <WagerCards
+              wagerId=""
+              wagerStatus="completed"
+              question="Will Bitcoin Hit $100k Before January 31, 2025?"
+              stakeAmount={100}
+              leftUser={{
+                username: "@noyi24_7",
+                icon: "/images/leftWagercardUserOneIcon.svg",
+              }}
+              rightUser={{
+                username: "@babykeem",
+                icon: "/images/rightWagercardUserOneIcon.svg",
+              }}
+            />
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/layouts/sidebar.tsx
+++ b/src/components/layouts/sidebar.tsx
@@ -44,10 +44,13 @@ export function SidebarDesktop() {
   return (
     <aside className=" hidden sticky top-0  w-[13rem] px-5 py-4  lg:flex flex-col items-center h-screen overflow-y-auto  bg-gray-900">
       <div className="w-full flex gap-8 flex-col items-center">
-        <Link href="/dashboard">{getSvgById("appLogo", { className: "w-28" })}</Link>
+        <Link href="/dashboard">
+          {getSvgById("appLogo", { className: "w-28" })}
+        </Link>
         <Link
           href="/dashboard/create-wager"
-          className="w-full flex items-center justify-center gap-3 text-base font-medium bg-secondary rounded-2xl p-4">
+          className="w-full flex items-center justify-center gap-3 text-base font-medium bg-secondary rounded-2xl p-4"
+        >
           {getSvgById("shake_fill_icon", { className: "fill-blue-950 w-5" })}
           New Wager
         </Link>
@@ -60,7 +63,8 @@ export function SidebarDesktop() {
                 `flex group fill-gray-500 text-gray-500 gap-2 flex-col items-center text-xs`
               )}
               href={item.url}
-              key={idx}>
+              key={idx}
+            >
               <div className="w-[3.5rem] h-8 justify-center flex flex-col items-center group-hover:fill-primary group-hover:bg-transparent bg-gray-800  rounded-2xl ">
                 {item.icon(
                   cn(
@@ -73,7 +77,8 @@ export function SidebarDesktop() {
                 className={cn(
                   `group-hover:text-primary`,
                   path === item.url && "text-secondary font-bold"
-                )}>
+                )}
+              >
                 {item.name}
               </span>
             </Link>
@@ -94,8 +99,9 @@ export function SidebarMobile() {
           {sideLinks.map((item, idx) => (
             <Link
               className="flex group w-full fill-gray-500 text-gray-500 gap-2 flex-col items-center text-xs"
-              href="#"
-              key={idx}>
+              href={item.url}
+              key={idx}
+            >
               <div className="w-[3.5rem] h-8 justify-center flex flex-col items-center group-hover:fill-primary group-hover:bg-transparent bg-gray-800  rounded-2xl ">
                 {item.icon(
                   cn(
@@ -108,7 +114,8 @@ export function SidebarMobile() {
                 className={cn(
                   `group-hover:text-primary`,
                   path === item.url && "text-secondary font-bold"
-                )}>
+                )}
+              >
                 {item.name}
               </span>
             </Link>

--- a/src/components/layouts/sidebar.tsx
+++ b/src/components/layouts/sidebar.tsx
@@ -93,7 +93,7 @@ export function SidebarMobile() {
   const path = usePathname();
 
   return (
-    <aside className="md:hidden left-0  fixed bottom-0 w-full  py-3 flex flex-col items-center   bg-gray-900">
+    <aside className="md:hidden left-0  z-10 fixed bottom-0 w-full  py-3 flex flex-col items-center   bg-gray-900">
       <div className="w-full">
         <div className="text-white flex justify-between w-full items-center gap-4">
           {sideLinks.map((item, idx) => (

--- a/src/components/ui/WagerCards.tsx
+++ b/src/components/ui/WagerCards.tsx
@@ -68,7 +68,7 @@ const WagerCards: React.FC<WagerCardProps> = ({
       </div>
 
       {/* Question */}
-      <h2 className="text-center text-blue-1 text-base md:text-xl font-medium mb-3">
+      <h2 className="text-center text-blue-1 text-sm sm:text-base md:text-xl font-medium mb-3">
         {question}
       </h2>
 
@@ -97,7 +97,7 @@ const WagerCards: React.FC<WagerCardProps> = ({
             alt={leftUser.username}
             width={56}
             height={56}
-            className="w-12 h-12 md:w-20 md:h-20 rounded-lg mb-1"
+            className="w-8 h-8 md:w-20 md:h-20 rounded-lg mb-1"
           />
           <span className="text-blue-1 font-medium text-[12px] md:text-sm">
             {leftUser.username}
@@ -121,7 +121,7 @@ const WagerCards: React.FC<WagerCardProps> = ({
             alt={rightUser.username}
             width={56}
             height={56}
-            className="w-12 h-12 md:w-20 md:h-20 rounded-lg mb-1"
+            className="w-8 h-8 md:w-20 md:h-20 rounded-lg mb-1"
           />
           <span className="text-blue-1 font-medium text-[12px] md:text-sm">
             {rightUser.username}

--- a/src/components/ui/WagerCards.tsx
+++ b/src/components/ui/WagerCards.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 interface WagerCardProps {
   question?: string;
-  progress: boolean;
+  wagerStatus: "active" | "pending" | "completed";
   stakeAmount?: number;
   leftUser: {
     username: string;
@@ -17,24 +17,41 @@ interface WagerCardProps {
 
 const WagerCards: React.FC<WagerCardProps> = ({
   question,
-  progress,
+  wagerStatus,
   stakeAmount,
   leftUser,
   rightUser,
 }) => {
+  const getStatusColor = () => {
+    switch (wagerStatus) {
+      case "active":
+        return "bg-green-500";
+      case "pending":
+        return "bg-[#EAAA08]";
+      case "completed":
+        return "bg-[#102A56]";
+    }
+  };
+
+  const getStatusText = () => {
+    switch (wagerStatus) {
+      case "active":
+        return "In Progress";
+      case "pending":
+        return "Pending";
+      case "completed":
+        return "Completed";
+    }
+  };
   return (
     <div className="w-full p-4 bg-white mt-3 rounded-lg">
       {/* Status Indicator */}
       <div className="flex items-center justify-center gap-2 mb-2">
         {/* Progress Indicator */}
-        <div
-          className={`w-2 h-2 rounded-full ${
-            progress ? "bg-green-500" : "bg-[#EAAA08]"
-          }`}
-        ></div>
+        <div className={`w-2 h-2 rounded-full ${getStatusColor()}`}></div>
 
         <span className="text-gray-600 text-[13px] md:text-sm">
-          {progress ? "In Progress" : "Pending"}
+          {getStatusText()}
         </span>
       </div>
 

--- a/src/components/ui/WagerCards.tsx
+++ b/src/components/ui/WagerCards.tsx
@@ -29,7 +29,7 @@ const WagerCards: React.FC<WagerCardProps> = ({
   const router = useRouter();
 
   const handleCardClick = () => {
-    router.push(`/wagers/${wagerId}`);
+    router.push(`/dashboard/wagers/wagers_summary?wagerId=${wagerId}`);
   };
 
   const getStatusColor = () => {

--- a/src/components/ui/WagerCards.tsx
+++ b/src/components/ui/WagerCards.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { useRouter } from "next/navigation"; // Import router for navigation
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 
 interface WagerCardProps {

--- a/src/components/ui/WagerCards.tsx
+++ b/src/components/ui/WagerCards.tsx
@@ -1,7 +1,10 @@
+"use client";
 import React from "react";
+import { useRouter } from "next/navigation"; // Import router for navigation
 import Image from "next/image";
 
 interface WagerCardProps {
+  wagerId: string;
   question?: string;
   wagerStatus: "active" | "pending" | "completed";
   stakeAmount?: number;
@@ -16,12 +19,19 @@ interface WagerCardProps {
 }
 
 const WagerCards: React.FC<WagerCardProps> = ({
+  wagerId,
   question,
   wagerStatus,
   stakeAmount,
   leftUser,
   rightUser,
 }) => {
+  const router = useRouter();
+
+  const handleCardClick = () => {
+    router.push(`/wagers/${wagerId}`);
+  };
+
   const getStatusColor = () => {
     switch (wagerStatus) {
       case "active":
@@ -43,13 +53,15 @@ const WagerCards: React.FC<WagerCardProps> = ({
         return "Completed";
     }
   };
+
   return (
-    <div className="w-full p-4 bg-white mt-3 rounded-lg">
+    <div
+      className="w-full p-4 bg-white mt-3 rounded-lg cursor-pointer hover:shadow-sm transition"
+      onClick={handleCardClick}
+    >
       {/* Status Indicator */}
       <div className="flex items-center justify-center gap-2 mb-2">
-        {/* Progress Indicator */}
         <div className={`w-2 h-2 rounded-full ${getStatusColor()}`}></div>
-
         <span className="text-gray-600 text-[13px] md:text-sm">
           {getStatusText()}
         </span>

--- a/src/components/ui/error.tsx
+++ b/src/components/ui/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+export default function ErrorPage() {
+  const router = useRouter();
+
+  return (
+    <div className="w-full h-screen flex flex-col justify-center items-center bg-white text-center p-6">
+      <h1 className="text-3xl font-bold text-blue-1 mt-4">
+        <span className="text-[#E0FE10]">Oops!</span> Something Went Wrong
+      </h1>
+      <p className="text-gray-600 mt-2 text-sm md:text-base">
+        An unexpected error occurred. Please try again.
+      </p>
+
+      <div className="mt-6 flex gap-4">
+        <button
+          onClick={() => router.push("/")}
+          className="px-4 py-2 bg-[#E0FE10] text-[#102A56] rounded-lg hover:bg-[#E0FE10]/50 transition"
+        >
+          Go Home
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeletons/wagerCardSkeleton.tsx
+++ b/src/components/ui/skeletons/wagerCardSkeleton.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+function WagerCardSkeleton() {
+  return (
+    <div className="w-full p-4 bg-white mt-3 rounded-lg animate-pulse">
+      {/* Status Indicator */}
+      <div className="flex items-center justify-center gap-2 mb-2">
+        <div className="w-2 h-2 rounded-full bg-gray-300"></div>
+        <span className="text-gray-400 text-[13px] md:text-sm">Loading...</span>
+      </div>
+
+      {/* Question */}
+      <div className="h-6 bg-gray-300 rounded w-3/4 mx-auto mb-3"></div>
+
+      {/* Stake Amount */}
+      <div className="flex justify-center mb-8">
+        <div className="bg-gray-200 rounded-full px-4 py-2 flex items-center gap-2 w-1/3">
+          <div className="w-4 h-4 bg-gray-300 rounded-full"></div>
+          <div className="h-4 w-16 bg-gray-300 rounded"></div>
+        </div>
+      </div>
+
+      {/* Users */}
+      <div className="flex justify-between items-center gap-4 md:gap-8 px-6 md:px-10 lg:px-14">
+        <div className="text-center">
+          <div className="w-12 h-12 md:w-20 md:h-20 bg-gray-300 rounded-lg mb-1"></div>
+          <div className="h-4 w-16 bg-gray-300 rounded"></div>
+        </div>
+
+        <div className="flex flex-col items-center">
+          <div className="h-4 w-12 bg-gray-300 rounded"></div>
+          <div className="h-6 w-12 bg-gray-300 rounded mt-1"></div>
+        </div>
+
+        <div className="text-center">
+          <div className="w-12 h-12 md:w-20 md:h-20 bg-gray-300 rounded-lg mb-1"></div>
+          <div className="h-4 w-16 bg-gray-300 rounded"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WagerCardSkeleton;

--- a/src/components/ui/skeletons/wagerCardSkeleton.tsx
+++ b/src/components/ui/skeletons/wagerCardSkeleton.tsx
@@ -3,16 +3,13 @@ import React from "react";
 function WagerCardSkeleton() {
   return (
     <div className="w-full p-4 bg-white mt-3 rounded-lg animate-pulse">
-      {/* Status Indicator */}
       <div className="flex items-center justify-center gap-2 mb-2">
         <div className="w-2 h-2 rounded-full bg-gray-300"></div>
         <span className="text-gray-400 text-[13px] md:text-sm">Loading...</span>
       </div>
 
-      {/* Question */}
       <div className="h-6 bg-gray-300 rounded w-3/4 mx-auto mb-3"></div>
 
-      {/* Stake Amount */}
       <div className="flex justify-center mb-8">
         <div className="bg-gray-200 rounded-full px-4 py-2 flex items-center gap-2 w-1/3">
           <div className="w-4 h-4 bg-gray-300 rounded-full"></div>
@@ -20,7 +17,6 @@ function WagerCardSkeleton() {
         </div>
       </div>
 
-      {/* Users */}
       <div className="flex justify-between items-center gap-4 md:gap-8 px-6 md:px-10 lg:px-14">
         <div className="text-center">
           <div className="w-12 h-12 md:w-20 md:h-20 bg-gray-300 rounded-lg mb-1"></div>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center  bg-none p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded px-5 py-2  text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 text-[#7D89B0] data-[state=active]:bg-[#E0FE10] data-[state=active]:text-[#102A56] data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
# Implement Wagers Page with Tabs (#63)

## Description
To build wagers page and implement all necessary tabs using Shadcn UI and adding the desired functionality and interactivity as required in the figma file provided.

## Changes made
- changed status boolean to  enum to handle more than 2 states
- added z index(z-10) to the mobile sidebar because the wagers page overlayed the sidebar on small screens.
- updated the href of the link  in mobile sidebar to accept item.url to enable navigation.


## Checklist / Technical Details
- Created a wagers page scratch according to the figma file provided
- Implemented Tabs and Tab switching using ShadCN UI components
-  Updated the wagercard component to accept 3 statuses "active",  "pending",  "completed", using enum  because the boolean type was insufficient to handle the wager status.
- Implemented a switch statement to dynamically set wager status colors and status text.
- Updated wagercard component to navigate to the summary page when clicked
- Created custom error component to handle errors location (/components/ui/error.tsx)
- Created a skeleton component and simulated loading state to improve UI. location( /components/ui/skeletons/wagercardskeleton.tsx)
- Made the components responsive accross all screens.


## File installation
- Installed ShadCN UI