### PR TITLE
Add Claim disclaimer modal and cancel claim button 

### DIFF
--- a/src/components/wagers/claim-disclaimer-modal.tsx
+++ b/src/components/wagers/claim-disclaimer-modal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+interface ClaimDisclaimerModalProps {
+  onClose: () => void;
+  onProceed: () => void;
+}
+
+const ClaimDisclaimerModal: React.FC<ClaimDisclaimerModalProps> = ({ 
+  onClose, 
+  onProceed 
+}) => {
+  return (
+    <div className="flex flex-col items-center p-6 mb-9 md:p-0 md:mb-0">
+      <h3 className="text-[#102A56] text-xl font-semibold text-center">
+        Important Disclaimer
+      </h3>
+      
+      <div className="my-6 px-2 text-center">
+        <p className="text-[#475467] mb-6">
+          Remember, your winnings are credited only after your opponent confirms your claim.
+        </p>
+        <p className="text-[#475467]">
+          Avoid claiming victory without solid proof, as this can complicate issue resolution.
+        </p>
+      </div>
+      
+      <div className="w-full flex flex-col gap-4 mt-6">
+        <Button
+          onClick={onClose}
+          className="w-full bg-white text-[#102A56] border border-[#E2E5EB] rounded-full py-4 h-auto hover:bg-gray-50"
+          type="button"
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={onProceed}
+          className="w-full bg-[#E0FE10] text-[#102A56] rounded-full py-4 h-auto hover:bg-[#E0FE10]/90"
+          type="button"
+        >
+          Proceed with Claim
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ClaimDisclaimerModal;

--- a/src/components/wagers/wager-layout.tsx
+++ b/src/components/wagers/wager-layout.tsx
@@ -1,36 +1,102 @@
-"use client";
+'use client'
 
-import { Info } from "lucide-react";
-import { ReactNode } from "react";
-import { Button } from "../ui/button";
+import { Info } from 'lucide-react'
+import { ReactNode, useState } from 'react'
+import { Button } from '../ui/button'
+import { ModalView } from '@/components/ui/modals'
+import ClaimDisclaimerModal from '@/components/wagers/claim-disclaimer-modal'
 
 interface WagerLayoutProps {
-  children: ReactNode;
-  showCreateButton?: boolean;
+  children: ReactNode
+  showCreateButton?: boolean
+  showClaimButton?: boolean
 }
 
-export function WagerLayout({ children, showCreateButton = false }: WagerLayoutProps) {
-  return (
-    <div className="mx-auto pb-20 lg:pb-5 max-w-xl">
-      <div className="gap-4 grid">
-        {children}
-      </div>
+export function WagerLayout({
+  children,
+  showCreateButton = false,
+  showClaimButton = false,
+}: WagerLayoutProps) {
+  const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false)
+  const [hasClaimed, setHasClaimed] = useState(false)
 
-      <section className="py-6 mt-6 grid gap-8 border-t">
-        <div className="flex items-center gap-3 rounded-sm border bg-white pl-3 p-3 text-blue-1">
-          <Info className="h-5 w-5 flex-shrink-0" />
-          <p className="text-sm md:text-base font-medium">
-            Always keep verifiable evidence of your wagers for dispute
-            resolution purposes.
-          </p>
-        </div>
+  const handleClaimClick = () => {
+    setIsDisclaimerOpen(true)
+  }
 
-        {showCreateButton && (
-          <Button size={"lg"} className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium tracking-[-0.36px]">
-            Create Wager
+  const handleClaimProceed = () => {
+    setIsDisclaimerOpen(false)
+    setHasClaimed(true)
+  }
+
+  const handleCancelClaim = () => {
+    setHasClaimed(false)
+  }
+
+  const renderButton = () => {
+    if (showClaimButton) {
+      if (hasClaimed) {
+        return (
+          <Button
+            onClick={handleCancelClaim}
+            className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium bg-white border border-[#E2E5EB] text-[#102A56] hover:bg-gray-50 transition-all duration-300"
+          >
+            Cancel Claim
           </Button>
-        )}
-      </section>
-    </div>
-  );
+        )
+      }
+
+      return (
+        <Button
+          onClick={handleClaimClick}
+          className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium transition-all duration-300"
+        >
+          Claim Win
+        </Button>
+      )
+    }
+
+    if (showCreateButton) {
+      return (
+        <Button
+          size={'lg'}
+          className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium tracking-[-0.36px]"
+        >
+          Create Wager
+        </Button>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <>
+      <ModalView
+        open={isDisclaimerOpen}
+        setOpen={setIsDisclaimerOpen}
+        className="max-w-[400px] p-6 rounded-2xl"
+      >
+        <ClaimDisclaimerModal
+          onClose={() => setIsDisclaimerOpen(false)}
+          onProceed={handleClaimProceed}
+        />
+      </ModalView>
+
+      <div className="mx-auto pb-20 lg:pb-5 max-w-xl">
+        <div className="gap-4 grid">{children}</div>
+
+        <section className="py-6 mt-6 grid gap-8 border-t">
+          <div className="flex items-center gap-3 rounded-sm border bg-white pl-3 p-3 text-blue-1">
+            <Info className="h-5 w-5 flex-shrink-0" />
+            <p className="text-sm md:text-base font-medium">
+              Always keep verifiable evidence of your wagers for dispute
+              resolution purposes.
+            </p>
+          </div>
+          {renderButton()}
+        </section>
+      </div>
+    </>
+  )
 }

--- a/src/module/dashboard/wagers/wagers_summary.tsx
+++ b/src/module/dashboard/wagers/wagers_summary.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { WagerLayout } from "@/components/wagers/wager-layout";
 import { BattleDisplay } from "@/components/wagers/battle-display";
 import { WagerDetails } from "@/components/wagers/wager_details";
@@ -28,7 +27,10 @@ const wagerDetails = {
 
 export default function WagerSummary() {
   const searchParams = useSearchParams();
-  const state = searchParams.get('state') || 'pending';
+  const state = searchParams.get('state') || 'pending'
+
+  const shouldShowClaimButton = state === 'active' || state === 'won';
+  const shouldShowCreateButton = state === 'pending';
 
   const renderBattleDisplay = () => {
     switch (state) {
@@ -76,12 +78,26 @@ export default function WagerSummary() {
           />
         );
       default:
-        return null;
+        return (   
+        <BattleDisplay
+          player1={{
+            username: "@noyi24_7",
+            avatar: "/images/avatar.svg"
+          }}
+          player2={{
+            username: "@@babykeem",
+            avatar: "/images/player2.svg"
+          }}
+          amount="5 STRK each"
+        />
+      );
     }
   };
 
   return (
-    <WagerLayout showCreateButton={state === 'pending'}>
+    <WagerLayout 
+      showCreateButton={shouldShowCreateButton}
+      showClaimButton={shouldShowClaimButton}>
       {renderBattleDisplay()}
       <WagerDetails {...wagerDetails} />
     </WagerLayout>


### PR DESCRIPTION
## Description
This PR implements the Claim Win functionality for wagers. When a user clicks the "Claim Win" button, a disclaimer modal appears with important information about the claiming process. After confirmation, the button changes to "Cancel Claim" to allow users to reverse their action if needed. The implementation follows existing UI/UX guidelines and is fully responsive across all device sizes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist
- [x] My code follows the code style of this project.
- [x] UI components match the existing design system.
- [x] Responsive design has been implemented and tested.
- [x] State management for button toggling works correctly.

## Related Issue
- Issue #64 

## Screenshots
<img width="366" alt="Screenshot 2025-02-27 at 6 40 43 AM" src="https://github.com/user-attachments/assets/ccdb476d-8087-47fa-b687-12abd60702f2" />
<img width="1440" alt="Screenshot 2025-02-27 at 6 41 41 AM" src="https://github.com/user-attachments/assets/fb2df69d-d5e5-4ec5-a952-9078a0153a0c" />
<img width="1440" alt="Screenshot 2025-02-27 at 6 41 52 AM" src="https://github.com/user-attachments/assets/5053af35-3136-4b02-b05c-c44489b8d6a7" />

