### PR TITLE
Feat/claim dispute flow

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<'textarea'>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/src/components/wagers/disagreement-modal.tsx
+++ b/src/components/wagers/disagreement-modal.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '../ui/textarea';
+
+interface DisclaimerModalProps {
+  onClose: () => void;
+  onProceed: (reason: string) => void;
+}
+
+const DisagreementModal: React.FC<DisclaimerModalProps> = ({
+  onClose,
+  onProceed,
+}) => {
+  const [reason, setReason] = useState('');
+  const charCount = reason.length;
+
+  const handleProceed = () => {
+    onProceed(reason);
+  };
+
+  return (
+    <div className='flex flex-col items-center p-6 mb-9 md:p-0 md:mb-0'>
+      <h3 className='text-[#102A56] text-xl font-semibold text-center'>
+        Important Disclaimer
+      </h3>
+
+      <p className='text-[#475467] text-center'>
+        You’ve just disagreed with this claim.
+      </p>
+
+      <div className='w-full max-w-[320px] mt-4 mx-auto h-[1px] bg-[linear-gradient(to_right,_#e2e8f0_53%,_rgba(255,255,255,0)_0%)] bg-bottom bg-[length:20px_15px] bg-repeat-x'></div>
+
+      <p className='text-[#475467] text-center mt-4'>
+        Please request proof from{' '}
+        <span className='font-medium text-headingBlue'> @noyi24_7.</span>
+      </p>
+
+      <div className='w-full flex flex-col gap-2.5 mt-6'>
+        <div className='text-headingBlue font-medium text-sm'>
+          Reason for Dispute (Optional)
+        </div>
+
+        <div className='flex flex-col gap-2.5'>
+          <Textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            className='w-full !text-lg placeholder:text-[#B9C0D4] placeholder:font-medium bg-[#EFF1F5] text-[#102A56] border-none rounded-lg py-4 h-auto hover:bg-[#EFF1F5]'
+            placeholder='Why do you disagree?'
+          />
+          <div className='flex justify-end'>
+            <p className='text-sm text-muted-foreground'>{charCount}/500</p>
+          </div>
+        </div>
+
+        <div className='w-full flex gap-4 mt-6'>
+          <Button
+            onClick={onClose}
+            className='w-fit bg-[#F9F9FB] text-headingBlue rounded-2xl py-4 h-auto hover:bg-[#F9F9FB]'
+            type='button'
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleProceed}
+            className='w-full bg-[#E0FE10] text-headingBlue rounded-2xl py-4 h-auto hover:bg-[#E0FE10]/90'
+            type='button'
+          >
+            Request Proof
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DisagreementModal;

--- a/src/components/wagers/wager-layout.tsx
+++ b/src/components/wagers/wager-layout.tsx
@@ -1,15 +1,16 @@
-'use client'
+'use client';
 
-import { Info } from 'lucide-react'
-import { ReactNode, useState } from 'react'
-import { Button } from '../ui/button'
-import { ModalView } from '@/components/ui/modals'
-import ClaimDisclaimerModal from '@/components/wagers/claim-disclaimer-modal'
+import { Info } from 'lucide-react';
+import { ReactNode, useState } from 'react';
+import { Button } from '../ui/button';
+import { ModalView } from '@/components/ui/modals';
+import ClaimDisclaimerModal from '@/components/wagers/claim-disclaimer-modal';
+import DisagreementModal from './disagreement-modal';
 
 interface WagerLayoutProps {
-  children: ReactNode
-  showCreateButton?: boolean
-  showClaimButton?: boolean
+  children: ReactNode;
+  showCreateButton?: boolean;
+  showClaimButton?: boolean;
 }
 
 export function WagerLayout({
@@ -17,21 +18,28 @@ export function WagerLayout({
   showCreateButton = false,
   showClaimButton = false,
 }: WagerLayoutProps) {
-  const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false)
-  const [hasClaimed, setHasClaimed] = useState(false)
+  const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false);
+  const [hasClaimed, setHasClaimed] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [isClaimedByOpponent, setIsClaimedByOpponent] = useState(true);
+  const [isDisagreementOpen, setIsDisagreementOpen] = useState(false);
 
   const handleClaimClick = () => {
-    setIsDisclaimerOpen(true)
-  }
+    setIsDisclaimerOpen(true);
+  };
 
   const handleClaimProceed = () => {
-    setIsDisclaimerOpen(false)
-    setHasClaimed(true)
-  }
+    setIsDisclaimerOpen(false);
+    setHasClaimed(true);
+  };
 
   const handleCancelClaim = () => {
-    setHasClaimed(false)
-  }
+    setHasClaimed(false);
+  };
+
+  const handleDisagreement = () => {
+    setIsDisagreementOpen(true);
+  };
 
   const renderButton = () => {
     if (showClaimButton) {
@@ -39,43 +47,58 @@ export function WagerLayout({
         return (
           <Button
             onClick={handleCancelClaim}
-            className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium bg-white border border-[#E2E5EB] text-[#102A56] hover:bg-gray-50 transition-all duration-300"
+            className='w-full max-w-[343px] mx-auto h-14 text-lg font-medium bg-white border border-[#E2E5EB] text-[#102A56] hover:bg-gray-50 transition-all duration-300'
           >
             Cancel Claim
           </Button>
-        )
+        );
       }
 
       return (
         <Button
           onClick={handleClaimClick}
-          className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium transition-all duration-300"
+          className='w-full max-w-[343px] mx-auto h-14 text-lg font-medium transition-all duration-300'
         >
           Claim Win
         </Button>
-      )
+      );
     }
 
     if (showCreateButton) {
       return (
         <Button
           size={'lg'}
-          className="w-full max-w-[343px] mx-auto h-14 text-lg font-medium tracking-[-0.36px]"
+          className='w-full max-w-[343px] mx-auto h-14 text-lg font-medium tracking-[-0.36px]'
         >
           Create Wager
         </Button>
-      )
+      );
     }
 
-    return null
-  }
+    if (isClaimedByOpponent) {
+      return (
+        <div className='flex gap-3 mt-5'>
+          <Button
+            onClick={handleDisagreement}
+            className='w-full bg-[#102A56] hover:bg-[#102A56]/90 flex items-center md:text-lg text-white font-medium'
+          >
+            Disagree
+          </Button>
+          <Button className='w-full hover:opacity-90 flex items-center md:text-lg font-medium'>
+            Agree
+          </Button>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <>
       <ModalView
         open={isDisclaimerOpen}
         setOpen={setIsDisclaimerOpen}
-        className="max-w-[400px] p-6 rounded-2xl"
+        className='max-w-[400px] p-6 rounded-2xl'
       >
         <ClaimDisclaimerModal
           onClose={() => setIsDisclaimerOpen(false)}
@@ -83,13 +106,24 @@ export function WagerLayout({
         />
       </ModalView>
 
-      <div className="mx-auto pb-20 lg:pb-5 max-w-xl">
-        <div className="gap-4 grid">{children}</div>
+      <ModalView
+        open={isDisagreementOpen}
+        setOpen={() => setIsDisagreementOpen(false)}
+        className='max-w-[400px] p-6 rounded-2xl'
+      >
+        <DisagreementModal
+          onClose={() => setIsDisagreementOpen(false)}
+          onProceed={() => {}}
+        />
+      </ModalView>
 
-        <section className="py-6 mt-6 grid gap-8 border-t">
-          <div className="flex items-center gap-3 rounded-sm border bg-white pl-3 p-3 text-blue-1">
-            <Info className="h-5 w-5 flex-shrink-0" />
-            <p className="text-sm md:text-base font-medium">
+      <div className='mx-auto pb-20 lg:pb-5 max-w-xl'>
+        <div className='gap-4 grid'>{children}</div>
+
+        <section className='py-6 mt-6 grid gap-8 border-t'>
+          <div className='flex items-center gap-3 rounded-sm border bg-white pl-3 p-3 text-blue-1'>
+            <Info className='h-5 w-5 flex-shrink-0' />
+            <p className='text-sm md:text-base font-medium'>
               Always keep verifiable evidence of your wagers for dispute
               resolution purposes.
             </p>
@@ -98,5 +132,5 @@ export function WagerLayout({
         </section>
       </div>
     </>
-  )
+  );
 }

--- a/src/components/wagers/wager-layout.tsx
+++ b/src/components/wagers/wager-layout.tsx
@@ -113,7 +113,7 @@ export function WagerLayout({
       >
         <DisagreementModal
           onClose={() => setIsDisagreementOpen(false)}
-          onProceed={() => {}}
+          onProceed={() => setIsDisagreementOpen(false)}
         />
       </ModalView>
 

--- a/src/components/wagers/wager-layout.tsx
+++ b/src/components/wagers/wager-layout.tsx
@@ -11,17 +11,17 @@ interface WagerLayoutProps {
   children: ReactNode;
   showCreateButton?: boolean;
   showClaimButton?: boolean;
+  isClaimedByOpponent?: boolean;
 }
 
 export function WagerLayout({
   children,
   showCreateButton = false,
   showClaimButton = false,
+  isClaimedByOpponent = false,
 }: WagerLayoutProps) {
   const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false);
   const [hasClaimed, setHasClaimed] = useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [isClaimedByOpponent, setIsClaimedByOpponent] = useState(true);
   const [isDisagreementOpen, setIsDisagreementOpen] = useState(false);
 
   const handleClaimClick = () => {

--- a/src/module/dashboard/wagers/wagers_summary.tsx
+++ b/src/module/dashboard/wagers/wagers_summary.tsx
@@ -1,36 +1,38 @@
-"use client";
-import { WagerLayout } from "@/components/wagers/wager-layout";
-import { BattleDisplay } from "@/components/wagers/battle-display";
-import { WagerDetails } from "@/components/wagers/wager_details";
-import { useSearchParams } from "next/navigation";
+'use client';
+import { WagerLayout } from '@/components/wagers/wager-layout';
+import { BattleDisplay } from '@/components/wagers/battle-display';
+import { WagerDetails } from '@/components/wagers/wager_details';
+import { useSearchParams } from 'next/navigation';
 
 const wagerDetails = {
-  title: "Will Bitcoin Hit $100k Before January 31, 2025?",
-  potentialWinnings: "10 STRK",
-  platformFee: "5.0%",
+  title: 'Will Bitcoin Hit $100k Before January 31, 2025?',
+  potentialWinnings: '10 STRK',
+  platformFee: '5.0%',
   description: [
     "Think Bitcoin is on track to skyrocket past $100k? Here's your chance to put your prediction to the test! This wager challenges participants to predict whether Bitcoin will reach or exceed the $100,000 mark by January 31, 2025. The official price will be determined using CoinMarketCap's data at 11:59 PM UTC on the deadline date.",
     "Participants must stake an equal amount of STRK tokens to join this head-to-head challenge. If Bitcoin hits or surpasses $100k by the specified date and time, those who wager 'Yes' win the wager. If it falls short, those who wager 'No' take the prize.",
-    "No extensions, no exceptions—this is your chance to back your crypto knowledge with real stakes! Join now and see if your prediction skills can earn you the ultimate reward in STRK tokens. Let's see who's got what it takes to call the next big crypto move!"
+    "No extensions, no exceptions—this is your chance to back your crypto knowledge with real stakes! Join now and see if your prediction skills can earn you the ultimate reward in STRK tokens. Let's see who's got what it takes to call the next big crypto move!",
   ],
   hashtags: [
-    "Bitcoin",
-    "STRKWager",
-    "BTCto100k",
-    "CryptoWagering",
-    "BlockchainWager",
-    "CryptoTrends",
-    "Web3Challenge",
-    "DeFiPrediction",
-  ]
+    'Bitcoin',
+    'STRKWager',
+    'BTCto100k',
+    'CryptoWagering',
+    'BlockchainWager',
+    'CryptoTrends',
+    'Web3Challenge',
+    'DeFiPrediction',
+  ],
 };
 
 export default function WagerSummary() {
   const searchParams = useSearchParams();
-  const state = searchParams.get('state') || 'pending'
+  const state = searchParams.get('state') || 'pending';
 
   const shouldShowClaimButton = state === 'active' || state === 'won';
   const shouldShowCreateButton = state === 'pending';
+
+  console.log('shouldShowCreateButton', shouldShowCreateButton);
 
   const renderBattleDisplay = () => {
     switch (state) {
@@ -38,66 +40,67 @@ export default function WagerSummary() {
         return (
           <BattleDisplay
             player1={{
-              username: "@noyi24_7",
-              avatar: "/images/avatar.svg"
+              username: '@noyi24_7',
+              avatar: '/images/avatar.svg',
             }}
             isPending
-            amount="5 STRK each"
+            amount='5 STRK each'
           />
         );
       case 'won':
         return (
           <BattleDisplay
             player1={{
-              username: "@noyi24_7",
-              avatar: "/images/avatar.svg",
-              isWinner: true
+              username: '@noyi24_7',
+              avatar: '/images/avatar.svg',
+              isWinner: true,
             }}
             player2={{
-              username: "@@babykeem",
-              avatar: "/images/player2.svg",
-              isWinner: false
+              username: '@@babykeem',
+              avatar: '/images/player2.svg',
+              isWinner: false,
             }}
-            amount="5 STRK each"
+            amount='5 STRK each'
           />
         );
       case 'lost':
         return (
           <BattleDisplay
             player1={{
-              username: "@noyi24_7",
-              avatar: "/images/avatar.svg",
-              isWinner: false
+              username: '@noyi24_7',
+              avatar: '/images/avatar.svg',
+              isWinner: false,
             }}
             player2={{
-              username: "@@babykeem",
-              avatar: "/images/player2.svg",
-              isWinner: true
+              username: '@@babykeem',
+              avatar: '/images/player2.svg',
+              isWinner: true,
             }}
-            amount="5 STRK each"
+            amount='5 STRK each'
           />
         );
       default:
-        return (   
-        <BattleDisplay
-          player1={{
-            username: "@noyi24_7",
-            avatar: "/images/avatar.svg"
-          }}
-          player2={{
-            username: "@@babykeem",
-            avatar: "/images/player2.svg"
-          }}
-          amount="5 STRK each"
-        />
-      );
+        return (
+          <BattleDisplay
+            player1={{
+              username: '@noyi24_7',
+              avatar: '/images/avatar.svg',
+            }}
+            player2={{
+              username: '@@babykeem',
+              avatar: '/images/player2.svg',
+            }}
+            amount='5 STRK each'
+          />
+        );
     }
   };
 
   return (
-    <WagerLayout 
-      showCreateButton={shouldShowCreateButton}
-      showClaimButton={shouldShowClaimButton}>
+    <WagerLayout
+      showCreateButton={false}
+      showClaimButton={shouldShowClaimButton}
+    >
       {renderBattleDisplay()}
       <WagerDetails {...wagerDetails} />
     </WagerLayout>

--- a/src/module/dashboard/wagers/wagers_summary.tsx
+++ b/src/module/dashboard/wagers/wagers_summary.tsx
@@ -23,16 +23,31 @@ const wagerDetails = {
     'Web3Challenge',
     'DeFiPrediction',
   ],
+  claimStatus: {
+    // ? change this to toggle between claimed and not claimed
+    isClaimed: true,
+    claimedBy: '@babykeem',
+    dispute: {
+      initiated: false,
+      reason: '',
+      proofRequested: false,
+    },
+  },
 };
 
 export default function WagerSummary() {
   const searchParams = useSearchParams();
   const state = searchParams.get('state') || 'pending';
 
-  const shouldShowClaimButton = state === 'active' || state === 'won';
+  const shouldShowClaimButton =
+    (state === 'active' || state === 'won') &&
+    !wagerDetails.claimStatus?.isClaimed;
   const shouldShowCreateButton = state === 'pending';
 
-  console.log('shouldShowCreateButton', shouldShowCreateButton);
+  const isClaimedByOpponent = wagerDetails.claimStatus?.isClaimed;
+  // !This is to make sure that the claim is not by you and is truly done,
+  // ! the opponent. This cannot be used yet until integration where we have users data
+  // && wagerDetails.claimStatus?.claimedBy !== '@currentUser';
 
   const renderBattleDisplay = () => {
     switch (state) {
@@ -98,8 +113,9 @@ export default function WagerSummary() {
 
   return (
     <WagerLayout
-      showCreateButton={false}
+      showCreateButton={shouldShowCreateButton}
       showClaimButton={shouldShowClaimButton}
+      isClaimedByOpponent={isClaimedByOpponent}
     >
       {renderBattleDisplay()}
       <WagerDetails {...wagerDetails} />


### PR DESCRIPTION
## Description
This PR implements the wager disagreement flow, allowing users to dispute claims made by their opponents in wagers. Key changes include:

- Added a new DisagreementModal component for handling dispute submissions
- Integrated dispute flow in WagerLayout with "Agree/Disagree" buttons
- Updated WagerSummary to handle claimed wager states and opponent interactions

The flow now allows users to:
1. See when an opponent has claimed a win
2. Choose to agree or disagree with the claim
3. Submit a dispute with an optional reason (up to 500 characters)
4. Request proof from the claiming party

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Dependencies
- Installed the `Textarea` component from Shadcn

## Checklist
- [x] My code follows the code style of this project
- [x] Components are properly typed with TypeScript
- [x] Modal interactions and state management implemented
- [x] UI is responsive and matches design specifications

## Related Issue
- Implements wager dispute flow from Issue #65 

## Testing
To test the flow you have to do the following;

1. Make sure that your wager summary url has it's state value set as `active`. For example
`/dashboard/wagers/wagers_summary?state=active`
2. Change the `isClaimed` field to true in the wagerDetails mockdata.
<img width="974" alt="Screenshot 2025-03-03 at 3 32 34 PM" src="https://github.com/user-attachments/assets/f58c78b1-7bb8-45c4-b1fd-b0db212784b3" />

## Screenshots
1. The Agree/Disagree buttons when a wager is claimed;
<img width="1217" alt="Screenshot 2025-03-03 at 3 34 36 PM" src="https://github.com/user-attachments/assets/c24bce50-4f25-4778-90c2-954731758eb5" />

2. The dispute modal with reason input;
<img width="1413" alt="Screenshot 2025-03-03 at 3 34 55 PM" src="https://github.com/user-attachments/assets/d241711c-8c73-4fb7-877b-a17011cf3108" />
