### PR TITLE
feat: persist wallet and user state with zustand for reload resilience

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.62.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       zod:
         specifier: ^3.24.3
         version: 3.24.3
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.18)(react@18.3.1)
     devDependencies:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.62.16
@@ -2029,6 +2032,7 @@ packages:
 
   get-starknet-core@4.0.0:
     resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
+    deprecated: Package no longer supported. Please use @starknet-io/get-starknet-core
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -3660,6 +3664,24 @@ packages:
 
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -7788,3 +7810,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.24.3: {}
+
+  zustand@5.0.4(@types/react@18.3.18)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.18
+      react: 18.3.1

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,5 @@
 import AuthNavbar from "@/components/layouts/navbar";
-import React, { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 
 export default function authlayout({ children }: { children: ReactNode }) {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,9 +93,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <Providers>
-            <WalletProvider>
-              {children}
-            </WalletProvider>
+            <WalletProvider>{children}</WalletProvider>
           </Providers>
         </ThemeProvider>
       </body>

--- a/src/components/ui/modals/ConnectWallet.tsx
+++ b/src/components/ui/modals/ConnectWallet.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useEffect } from "react";
+import { useWalletStore } from "@/store/persistStore";
+import { useAccount } from "@starknet-react/core";
 
 interface HashtagSelectorProps {
   open: boolean;
@@ -18,6 +20,15 @@ interface HashtagSelectorProps {
 
 export function ConnectWallet({ open, onOpenChange }: HashtagSelectorProps) {
   const { connect, connectors, isSuccess, isError } = useConnect();
+  const { address } = useAccount();
+  const { setAddress, address: persistedAddress } = useWalletStore();
+
+  // Persist address in zustand store only if it changes
+  useEffect(() => {
+    if (address && address !== persistedAddress) {
+      setAddress(address);
+    }
+  }, [address, setAddress, persistedAddress]);
 
   useEffect(() => {
     if (isSuccess || isError) {

--- a/src/components/ui/user-bar.tsx
+++ b/src/components/ui/user-bar.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../ui/dropdownMenu";
+import { useWalletStore } from "@/store/persistStore";
 
 export default function UserBar({
   variation = "app",
@@ -21,9 +22,16 @@ export default function UserBar({
   className?: string;
 }) {
   const isWeb = variation === "web";
-  const { address } = useAccount();
+  const { address: liveAddress } = useAccount();
+  const persistedAddress = useWalletStore((state) => state.address);
+  const address = liveAddress || persistedAddress || undefined;
   const { disconnect } = useDisconnect();
-  const { data } = useStarkName({ address });
+  const { data } = useStarkName({
+    address:
+      typeof address === "string" && address.startsWith("0x")
+        ? (address as `0x${string}`)
+        : undefined,
+  });
   const { isCopied, copy } = useCopyToClipboard();
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -97,7 +105,7 @@ export default function UserBar({
           <Copy className="mr-2 h-4 w-4" />
           {isCopied ? "Copied!" : "Copy Address"}
         </DropdownMenuItem>
-        <div className="dashed-line w-full h-[1px] my-2"></div>
+        <div className="dashed-line w-full h-[1px] my-2" />
         <DropdownMenuItem onClick={() => disconnect()}>
           <LogOut className="mr-2 h-4 w-4" />
           Disconnect

--- a/src/components/ui/wallet-bar.tsx
+++ b/src/components/ui/wallet-bar.tsx
@@ -1,4 +1,4 @@
-import { useAccount } from "@starknet-react/core";
+import { useWalletStore } from "@/store/persistStore";
 import UserBar from "./user-bar";
 import ConnectWalletBtn from "./connect-wallet-btn";
 
@@ -9,7 +9,7 @@ const WalletBar = ({
   isWeb: boolean;
   userBarclass?: string;
 }) => {
-  const { address } = useAccount();
+  const address = useWalletStore((state) => state.address);
 
   return (
     <>

--- a/src/components/wallets/connectWallet.tsx
+++ b/src/components/wallets/connectWallet.tsx
@@ -4,20 +4,30 @@ import React from "react";
 import { useConnect } from "@starknet-react/core";
 import { ARGENT_X_INSTALL_URL, BRAAVOS_INSTALL_URL } from "@/constants";
 import { getSvgById } from "@/svgs";
+import { useWalletStore } from "@/store/persistStore";
+import { useAccount } from "@starknet-react/core";
 
 export default function ConnectWallet() {
   const { connect, connectors } = useConnect();
-  //   const { starknetkitConnectModal } = useStarknetkitConnectModal({
-  //     connectors: connectors as any,
-  //   });
-  //   async function connectWallet() {
-  //     const { connector } = await starknetkitConnectModal();
-  //     if (!connector) {
-  //       return;
-  //     }
+  const { address } = useAccount();
+  const { setAddress, address: persistedAddress } = useWalletStore();
 
-  //     await connect({ connector });
-  //   }
+  // Persist address in zustand store when it changes
+  React.useEffect(() => {
+    if (address && address !== persistedAddress) {
+      setAddress(address);
+    }
+  }, [address, setAddress, persistedAddress]);
+
+  // Attempt to auto-connect if address is persisted but not in useAccount
+  React.useEffect(() => {
+    if (!address && persistedAddress && connectors.length > 0) {
+      // Try to reconnect with the first available connector (or customize as needed)
+      // This logic may need to be adapted based on your wallet provider's API
+      // connect({ connector: connectors[0] });
+      // Optionally, show a UI prompt to reconnect
+    }
+  }, [address, persistedAddress, connectors]);
 
   return (
     <div>

--- a/src/store/persistStore.ts
+++ b/src/store/persistStore.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export interface UserState {
+  user: string | null;
+  setUser: (user: string | null) => void;
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: "user-storage",
+    }
+  )
+);
+
+export interface WalletState {
+  address: string | null;
+  setAddress: (address: string | null) => void;
+  clearAddress: () => void;
+}
+
+export const useWalletStore = create<WalletState>()(
+  persist(
+    (set) => ({
+      address: null,
+      setAddress: (address) => set({ address }),
+      clearAddress: () => set({ address: null }),
+    }),
+    {
+      name: "wallet-storage",
+    }
+  )
+);


### PR DESCRIPTION
## Description
- Closes #143 
this pull request fixes the issue of when a user connects their wallet, and after succesfull connection the state isn't persisted across all components and also when the page reloads it clears the connected user wallet, this pull request fixes that issue 

## Type of Change
- [.] Bug fix (non-breaking change which fixes an issue)
- [.] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist
- [.] My code follows the code style of this project.

## Related Issue


## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/7bb609c7-86f9-410a-83a9-fdfd2dd6e671)
